### PR TITLE
Add PUMA: Semantic-Preserving Early Exit for Reasoning Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Awesome-Efficient-Inference-for-LRMs is a collection of state-of-the-art, novel,
 
 | Time    | Title                                                        | Venue |                  Paper                   |                             Code                             |
 | ------- | ------------------------------------------------------------ | :---: | :--------------------------------------: | :----------------------------------------------------------: |
+| 2026.05 | **Stop When Reasoning Converges: Semantic-Preserving Early Exit for Reasoning Models** |   arXiv'26     | [link](https://arxiv.org/pdf/2605.17672) |        [link](https://github.com/giovanni-vaccarino/PUMA)      |
 | 2025.05 | **Can Pruning Improve Reasoning? Revisiting Long-CoT Compression with Capability in Mind for Better Reasoning** |   arXiv'25     | [link](https://arxiv.org/abs/2505.14582) |  -  |
 | 2025.05 | **Long-Short Chain-of-Thought Mixture Supervised Fine-Tuning Eliciting Efficient Reasoning in Large Language Models** |   arXiv'25     | [link](https://arxiv.org/pdf/2505.03469) |        [link](https://github.com/ZGCA-AI4Edu/LS-Mixture)      |
 | 2025.05 | **ConCISE: Confidence-guided Compression in Step-by-step Efficient Reasoning** |   arXiv'25     | [link](https://arxiv.org/abs/2505.19756) |        -      |


### PR DESCRIPTION
Adding **PUMA** (arXiv 2026-05) to **Explicit Compact CoT** at the top of the table, alongside sibling early-exit / CoT-compression methods (FlashThink, ThinkLess, TrimR, VeriThinker, "Verbosity-Aware Rationale Reduction") already in this section.

PUMA is a plug-and-play inference-time early-exit framework for Large Reasoning Models that uses **reasoning-level semantic redundancy** (rather than answer-level confidence/consistency) as the primary stopping signal: a lightweight Redundancy Detector (fine-tuned Qwen3-Embedding-0.6B with a contrastive objective) flags candidate exits when recent reasoning steps stop adding novel progress; an Answer Verification window confirms whether stopping is safe.

Results across 5 LRMs (DeepSeek-R1-Distill-Qwen-7B/14B/32B, Llama-3.1-Nemotron-Nano-8B, Qwen3-30B-A3B-Thinking) and 5 reasoning benchmarks (MATH-500, AIME24, AIME25, OlympiadBench, GPQA-Diamond): **26.2% average token reduction** with preserved (slightly improved) accuracy; 1.40× / 1.28× wall-clock speedup on DS-7B/14B. Also generalizes to LiveCodeBench (code) and zero-shot VLM reasoning (MathVista, MathVision).

- Paper: https://arxiv.org/abs/2605.17672
- Code:  https://github.com/giovanni-vaccarino/PUMA

Thanks for maintaining this list!